### PR TITLE
Add zero check to is_ternary

### DIFF
--- a/src/poly/derive/polynomial.rs
+++ b/src/poly/derive/polynomial.rs
@@ -294,7 +294,7 @@ macro_rules! impl_signed_poly_functions {
             /// If the polynomial's coefficients are ternary
             fn is_ternary(&self) -> bool {
                 for &e in self.coeffs.iter() {
-                    if e != 1 && e != -1 {
+                    if e != 1 && e != 0 && e != -1 {
                         return false;
                     }
                 }


### PR DESCRIPTION
When running `cargo test` several of the tests fail because `is_ternary` is missing a zero check.

<img width="578" alt="image" src="https://github.com/user-attachments/assets/d8b92cf1-894c-47c0-a9e7-e3ec1fc8e774">
